### PR TITLE
Amine/frontend/not found redirect

### DIFF
--- a/frontend/src/Components/EventForm.jsx
+++ b/frontend/src/Components/EventForm.jsx
@@ -23,6 +23,7 @@ export default function EventForm (props) {
     const [ materialsUrl, setMaterialsUrl ] = useState(''); 
     const [ important, setImportant ] = useState(false);
     const [ cohortsList, setCohortsList ] = useState([]);
+    const [ loading, setLoading ] = useState(true);
 
 
     const getCohortsList = () => {
@@ -82,13 +83,20 @@ export default function EventForm (props) {
         const getEvent = async (id) => {
             try {
                 const { data } = await axios.get(`/api/events/event/${id}`);
-                preFillEvent(data.payload)
+                preFillEvent(data.payload);
+                setLoading(false);
             } catch (err) {
-                setFeedback(err)
+                if (err.response && err.response.status === 404) {
+                    history.push('/404');
+                } else {
+                    setFeedback(err)
+                }
             }
         }
         if (eventId) {
             getEvent(eventId);
+        } else {
+            setLoading(false);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [formType, eventId]);
@@ -149,6 +157,10 @@ export default function EventForm (props) {
         } catch (err) {
             setFeedback(err);
         }
+    }
+
+    if (loading) {
+        return <h1>Spinner placeholder</h1>
     }
 
     return (

--- a/frontend/src/Components/EventRender.jsx
+++ b/frontend/src/Components/EventRender.jsx
@@ -18,13 +18,20 @@ export default function EventRender(props) {
     const [ loggedVolunteerRequestAccepted, setLoggedVolunteerRequestAccepted ] = useState(false);
     const [ acceptedVolunteers, setAcceptedVolunteers] = useState([]);
     const [ reload, SetReload ] = useState(false);
+    const [ loading, setLoading ] = useState(true);
+
 
     const getEvent = async(id) => {
         try {
             const { data } = await axios.get(`/api/events/event/${id}`);
             setSingleEvent(data.payload);
+            setLoading(false);
         } catch (err) {
-            setFeedback(err);
+            if (err.response && err.response.status === 404) {
+                history.push('/404');
+            } else {
+                setFeedback(err)
+            }
         }
     }
     useEffect(() => {
@@ -92,6 +99,9 @@ export default function EventRender(props) {
         volunteersList
     ]);
 
+    if (loading) {
+        return <h1>Spinner Placeholder</h1>
+    }
 
     return (
         <div className='container'>

--- a/frontend/src/Components/Feedback.jsx
+++ b/frontend/src/Components/Feedback.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 
 export default function Feedback({ feedback, resetFeedback }) {
     let secondaryModalToggle = '';

--- a/frontend/src/Components/Mentoring.jsx
+++ b/frontend/src/Components/Mentoring.jsx
@@ -68,7 +68,11 @@ export default function Mentoring (props) {
                 // ].filter(task => task[1]));
 
             } catch (err) {
-                setFeedback(err);
+                if (err.response && err.response.status === 404) {
+                    history.push('/404');
+                } else {
+                    setFeedback(err)
+                }
             }
         }
 

--- a/frontend/src/Components/ProfilePages/FellowProfilePage.jsx
+++ b/frontend/src/Components/ProfilePages/FellowProfilePage.jsx
@@ -10,6 +10,8 @@ export default function FellowProfilePage(props) {
     const [ events, setEvents ] = useState([]);
     const [ activeMentors, SetActiveMentors ] = useState([]);
     const [ pastMentors, setPastMentors ] = useState([]);
+    const [ loading, setLoading ] = useState(true);
+
 
     
     useEffect(() => {
@@ -18,6 +20,7 @@ export default function FellowProfilePage(props) {
                 if (fellowId) {
                     const { data } = await axios.get(`/api/fellows/id/${fellowId}`);
                     setFellow(data.payload);
+                    setLoading(false);
 
                     if (data.payload.mentors_list) {
                         const active = [];
@@ -63,13 +66,21 @@ export default function FellowProfilePage(props) {
                     // setCohort(response[2].data.payload.cohort);
                 }
             } catch (err) {
-                setFeedback(err);
+                if (err.response && err.response.status === 404) {
+                    history.push('/404');
+                } else {
+                    setFeedback(err)
+                }
             }
         }
 
         getFellowData();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fellowId])
+    }, [fellowId]);
+
+    if (loading) {
+        return <h1>Spinner Placeholder</h1>
+    }
 
     return (
         <>

--- a/frontend/src/Components/ProfilePages/VolunteerProfilePage.jsx
+++ b/frontend/src/Components/ProfilePages/VolunteerProfilePage.jsx
@@ -91,7 +91,11 @@ export default function VolunteerProfilePage(props) {
 
                 }
             } catch (err) {
-                setFeedback(err);
+                if (err.response && err.response.status === 404) {
+                    history.push('/404');
+                } else {
+                      setFeedback(err)
+                }
             }
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Redirect to `not found` page when unfound event, volunteer or fellow data
## Description
<!--- Describe your changes in detail -->
if a user types into the browser navigation an id for event, volunteer or fellow id that doesn't exist in the database, it gets redirected to `/404` which will render a not found page
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoiding having half filled pages and an error message if an non-existing id is entered by the user
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Frontend
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
