### PR TITLE
fix size type to number instead of string

### DIFF
--- a/frontend/src/Components/Spinner.jsx
+++ b/frontend/src/Components/Spinner.jsx
@@ -2,13 +2,8 @@ import React from 'react';
 import { AtomSpinner } from 'react-epic-spinners';
 
 const Spinner = (props) => {
-    let size = 300;
-    if (props.size) {
-        size = props.size;
-    }
-
     return (
-        <AtomSpinner className = {`spinner ${props.className}`} color = "#8d8558" size = {size}/>
+        <AtomSpinner className = {`spinner ${props.className}`} color = "#8d8558" size = {props.size || 300}/>
     );
 }
 

--- a/frontend/src/Components/Spinner.jsx
+++ b/frontend/src/Components/Spinner.jsx
@@ -2,15 +2,14 @@ import React from 'react';
 import { AtomSpinner } from 'react-epic-spinners';
 
 const Spinner = (props) => {
-    let size='300';
-    if(props.size){
-        size = props.size
-    } 
-    
+    let size = 300;
+    if (props.size) {
+        size = props.size;
+    }
+
     return (
         <AtomSpinner className = {`spinner ${props.className}`} color = "#8d8558" size = {size}/>
-       
-    )
+    );
 }
 
 export default Spinner;


### PR DESCRIPTION
## Description
change default variable type of Spinner component size to number type instead of string
 
## Motivation and Context
incorrect type was generating logged error in browser, possibly typescript in Spinner component

## How Has This Been Tested?
e2e in browsers

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings