### PR TITLE
new Volunteers dash tweak

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -83,5 +83,6 @@
     border-radius: var(--border-radii);
     font-weight: bold;
     margin-bottom: 1rem;
+    border: solid 1px #0c326b;
     padding: .75rem 1rem .4rem 1rem;
 }

--- a/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
+++ b/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
@@ -14,22 +14,15 @@ import VolunteerPreviewCard from './VolunteerPreviewCard';
 
 const NewVolunteersDash = (props) => {
   const { newVolunteers, reloadDashboard, setReloadDashboard, setFeedback } = props;
-  let slideNextRef = '';
 
 
   const acceptVolunteer = async (id) => {
     try {
         await axios.patch(`/api/volunteers/confirm/${id}`);
-        slideNextRef.click();
         setReloadDashboard(!reloadDashboard);
     } catch (err) {
         setFeedback(err)
     }
-  }
-
-  const testButton = (e) => { // convert this to delete function in future
-    e.preventDefault();
-    slideNextRef.click();
   }
 
   const slideIndicators = [];
@@ -59,7 +52,7 @@ const NewVolunteersDash = (props) => {
           className={index === 0 ? "carousel-item active" : "carousel-item"}
           key={v_first_name + v_last_name + v_id}
         >
-          <VolunteerPreviewCard volunteer={volunteer} acceptVolunteer={acceptVolunteer} testButton={testButton} />
+          <VolunteerPreviewCard volunteer={volunteer} acceptVolunteer={acceptVolunteer} />
         </div>
       );
   });
@@ -92,15 +85,6 @@ const NewVolunteersDash = (props) => {
                       </a>
                     </div>
                   </div>
-                  <a
-                    className='g1CarouselHidden'
-                    href="#newVolunteersSlideshow"
-                    role='button'
-                    data-slide='next'
-                    ref={input => { // this ref is used to target this link when slideNextRef.click() is called
-                        slideNextRef = input;
-                    }}
-                  >{' '}</a>
                 </div>
               </div>
             )

--- a/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
+++ b/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
@@ -69,7 +69,7 @@ const NewVolunteersDash = (props) => {
     <UIModule className='deepSangria g1NVDash' titleColor="New Volunteer" titleRegular='Signups'>
         {newVolunteers.length <= 0
           ? (
-              <div>There are no new volunteers awaiting confirmation.</div>
+              <div className='g1EmptyNewVolsMsg'>There are no new volunteers pending deliberation.</div>
             )
           : (
               <div id="newVolunteersSlideshow" className="g1NewVolCarousel carousel slide" data-ride="carousel" data-interval="false" data-touch="true">

--- a/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
+++ b/frontend/src/Components/Dashboards/NewVolunteersDash/NewVolunteersDash.jsx
@@ -14,15 +14,22 @@ import VolunteerPreviewCard from './VolunteerPreviewCard';
 
 const NewVolunteersDash = (props) => {
   const { newVolunteers, reloadDashboard, setReloadDashboard, setFeedback } = props;
+  let slideNextRef = '';
 
 
   const acceptVolunteer = async (id) => {
     try {
         await axios.patch(`/api/volunteers/confirm/${id}`);
+        slideNextRef.click();
         setReloadDashboard(!reloadDashboard);
     } catch (err) {
         setFeedback(err)
     }
+  }
+
+  const testButton = (e) => { // convert this to delete function in future
+    e.preventDefault();
+    slideNextRef.click();
   }
 
   const slideIndicators = [];
@@ -52,7 +59,7 @@ const NewVolunteersDash = (props) => {
           className={index === 0 ? "carousel-item active" : "carousel-item"}
           key={v_first_name + v_last_name + v_id}
         >
-          <VolunteerPreviewCard volunteer={volunteer} acceptVolunteer={acceptVolunteer}/>
+          <VolunteerPreviewCard volunteer={volunteer} acceptVolunteer={acceptVolunteer} testButton={testButton} />
         </div>
       );
   });
@@ -85,6 +92,15 @@ const NewVolunteersDash = (props) => {
                       </a>
                     </div>
                   </div>
+                  <a
+                    className='g1CarouselHidden'
+                    href="#newVolunteersSlideshow"
+                    role='button'
+                    data-slide='next'
+                    ref={input => { // this ref is used to target this link when slideNextRef.click() is called
+                        slideNextRef = input;
+                    }}
+                  >{' '}</a>
                 </div>
               </div>
             )

--- a/frontend/src/Components/Dashboards/NewVolunteersDash/VolunteerPreviewCard.jsx
+++ b/frontend/src/Components/Dashboards/NewVolunteersDash/VolunteerPreviewCard.jsx
@@ -24,7 +24,7 @@ export default function VolunteerPreviewCard(props) {
                 <div className='g1NewVolBtns col-6 offset-6 offset-lg-0 col-lg-3 mb-3 mb-lg-0'>
                     <button className='btn btn-success mb-lg-1' onClick={e => props.acceptVolunteer(volunteer.v_id)}>Accept</button>
                     <button className='btn btn-primary ml-2 ml-lg-0 mb-lg-1' onClick={handleEmailClick}>E-mail</button>
-                    <button className='btn btn-danger ml-2 mx-lg-0' onClick={e => e.preventDefault()}>Dismiss</button>
+                    <button className='btn btn-danger ml-2 mx-lg-0' onClick={e => props.testButton(e)}>Dismiss</button>
                 </div>
 
                 <div className='g1NewVolData col-12 col-lg-9'> 

--- a/frontend/src/Components/Dashboards/NewVolunteersDash/VolunteerPreviewCard.jsx
+++ b/frontend/src/Components/Dashboards/NewVolunteersDash/VolunteerPreviewCard.jsx
@@ -24,7 +24,7 @@ export default function VolunteerPreviewCard(props) {
                 <div className='g1NewVolBtns col-6 offset-6 offset-lg-0 col-lg-3 mb-3 mb-lg-0'>
                     <button className='btn btn-success mb-lg-1' onClick={e => props.acceptVolunteer(volunteer.v_id)}>Accept</button>
                     <button className='btn btn-primary ml-2 ml-lg-0 mb-lg-1' onClick={handleEmailClick}>E-mail</button>
-                    <button className='btn btn-danger ml-2 mx-lg-0' onClick={e => props.testButton(e)}>Dismiss</button>
+                    <button className='btn btn-danger ml-2 mx-lg-0' onClick={e => e.preventDefault()}>Dismiss</button>
                 </div>
 
                 <div className='g1NewVolData col-12 col-lg-9'> 

--- a/frontend/src/styles/_new-volunteers-dash.scss
+++ b/frontend/src/styles/_new-volunteers-dash.scss
@@ -5,6 +5,19 @@
     }
 }
 
+.g1EmptyNewVolsMsg {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    min-height: inherit;
+
+    font-family: var(--ff-accent);
+    color: #882f70;
+    font-size: 1.2rem;
+    transform: translateY(-4%);
+}
+
 .g1NewVolCarousel {
     .carousel-indicators::before {
         content: 'Initials';


### PR DESCRIPTION
## Description
styled empty new volunteers dash to match with other app styling
~~created hidden carousel Next button with jquery attr data-slide to click() targeting its ref when Accept button is clicked so that the carousel advances. i targeted a new hidden button because ref.click() on the existing button would trigger css visible response on the current button~~

## Motivation and Context
visual coherence
~~fixes issue #136: carousel does not advance and hangs on empty slot when there are more volunteers pending.~~

## How Has This Been Tested?
e2e in browsers

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings